### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build image and Publish to Github Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{secrets.DOCKERHUB_USER}}/python-analytics
         username: ${{secrets.DOCKERHUB_USER}}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore